### PR TITLE
(SOLARCH-352) Initial azure module

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -73,7 +73,7 @@ resource "azurerm_linux_virtual_machine" "server" {
   tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.server_public_ip[count.index].ip_address
-    internal_fqdn = "${name}.${azurerm_network_interface.server_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "${self.name}.${azurerm_network_interface.server_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -154,7 +154,7 @@ resource "azurerm_linux_virtual_machine" "psql" {
   tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.psql_public_ip[count.index].ip_address
-    internal_fqdn = "${name}.${azurerm_network_interface.psql_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "${self.name}.${azurerm_network_interface.psql_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -244,7 +244,7 @@ resource "azurerm_linux_virtual_machine" "compiler" {
     tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.compiler_public_ip[count.index].ip_address
-    internal_fqdn = "${name}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "${self.name}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -322,7 +322,7 @@ resource "azurerm_linux_virtual_machine" "node" {
     tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.node_public_ip[count.index].ip_address
-    internal_fqdn = "${name}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "${self.name}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -20,7 +20,6 @@ resource "azurerm_public_ip" "server_public_ip" {
   location            = var.region
   count               = var.server_count
   allocation_method   = "Static"
-  domain_name_label   = "pe-server-${var.project}-${count.index}-${var.id}"
   tags = local.name_tag
 }
 
@@ -105,7 +104,6 @@ resource "azurerm_public_ip" "psql_public_ip" {
   location            = var.region
   count               = var.database_count
   allocation_method   = "Static"
-  domain_name_label   = "pe-psql-${var.project}-${count.index}-${var.id}"  
   tags = local.name_tag
 }
 
@@ -196,7 +194,6 @@ resource "azurerm_public_ip" "compiler_public_ip" {
   location            = var.region
   count               = var.compiler_count
   allocation_method   = "Static"
-  domain_name_label   = "pe-compiler-${var.project}-${count.index}-${var.id}"
   tags                = local.name_tag
 }
 
@@ -276,7 +273,6 @@ resource "azurerm_public_ip" "node_public_ip" {
   location            = var.region
   count               = var.node_count
   allocation_method   = "Static"
-  domain_name_label   = "pe-node-${var.project}-${count.index}-${var.id}"
   tags = local.name_tag
 }
 

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -73,7 +73,7 @@ resource "azurerm_linux_virtual_machine" "server" {
   tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.server_public_ip[count.index].ip_address
-    internal_fqdn = "${self.name}.${azurerm_network_interface.server_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "pe-server-${var.project}-${count.index}-${var.id}.${azurerm_network_interface.server_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -154,7 +154,7 @@ resource "azurerm_linux_virtual_machine" "psql" {
   tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.psql_public_ip[count.index].ip_address
-    internal_fqdn = "${self.name}.${azurerm_network_interface.psql_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "pe-psql-${var.project}-${count.index}-${var.id}.${azurerm_network_interface.psql_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -244,7 +244,7 @@ resource "azurerm_linux_virtual_machine" "compiler" {
     tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.compiler_public_ip[count.index].ip_address
-    internal_fqdn = "${self.name}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "pe-compiler-${var.project}-${count.index}-${var.id}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -322,7 +322,7 @@ resource "azurerm_linux_virtual_machine" "node" {
     tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.node_public_ip[count.index].ip_address
-    internal_fqdn = "${self.name}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "$pe-instance-${var.project}-${count.index}-${var.id}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -322,7 +322,7 @@ resource "azurerm_linux_virtual_machine" "node" {
     tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.node_public_ip[count.index].ip_address
-    internal_fqdn = "$pe-instance-${var.project}-${count.index}-${var.id}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "pe-instance-${var.project}-${count.index}-${var.id}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -244,7 +244,7 @@ resource "azurerm_linux_virtual_machine" "compiler" {
     tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.compiler_public_ip[count.index].ip_address
-    internal_fqdn = "compiler${count.index}.${azurerm_network_interface.compiler[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "compiler${count.index}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -322,7 +322,7 @@ resource "azurerm_linux_virtual_machine" "node" {
     tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.node_public_ip[count.index].ip_address
-    internal_fqdn = "node${count.index}.${azurerm_network_interface.node[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "node${count.index}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -69,7 +69,13 @@ resource "azurerm_linux_virtual_machine" "server" {
     version   = "latest"
   }
 
-  tags        = local.name_tag
+# Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
+# for consistency with other providers I thought it would work best to put these tags on the instance
+  tags        = {
+    Name = "pe-${var.project}-${var.id}"
+    public_ip_address = azurerm_public_ip.server_public_ip[count.index].ip_address
+    internal_fqdn = "server${count.index}.${azurerm_network_interface.server_nic[count.index].internal_domain_name_suffix}"
+  }
   
   # Using remote-execs on each instance deployment to ensure things are really
   # really up before doing to the next step, helps with Bolt plans that'll
@@ -145,7 +151,13 @@ resource "azurerm_linux_virtual_machine" "psql" {
     version   = "latest"
   }
 
-  tags        = local.name_tag
+# Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
+# for consistency with other providers I thought it would work best to put these tags on the instance
+  tags        = {
+    Name = "pe-${var.project}-${var.id}"
+    public_ip_address = azurerm_public_ip.psql_public_ip[count.index].ip_address
+    internal_fqdn = "psql${count.index}.${azurerm_network_interface.psql_nic[count.index].internal_domain_name_suffix}"
+  }
   
   # Using remote-execs on each instance deployment to ensure things are really
   # really up before doing to the next step, helps with Bolt plans that'll
@@ -230,7 +242,13 @@ resource "azurerm_linux_virtual_machine" "compiler" {
     version   = "latest"
   }
 
-  tags        = local.name_tag
+# Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
+# for consistency with other providers I thought it would work best to put these tags on the instance
+    tags        = {
+    Name = "pe-${var.project}-${var.id}"
+    public_ip_address = azurerm_public_ip.compiler_public_ip[count.index].ip_address
+    internal_fqdn = "compiler${count.index}.${azurerm_network_interface.compiler[count.index].internal_domain_name_suffix}"
+  }
   
   # Using remote-execs on each instance deployment to ensure things are really
   # really up before doing to the next step, helps with Bolt plans that'll
@@ -303,7 +321,13 @@ resource "azurerm_linux_virtual_machine" "node" {
     version   = "latest"
   }
 
-  tags        = local.name_tag
+# Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
+# for consistency with other providers I thought it would work best to put these tags on the instance
+    tags        = {
+    Name = "pe-${var.project}-${var.id}"
+    public_ip_address = azurerm_public_ip.node_public_ip[count.index].ip_address
+    internal_fqdn = "node${count.index}.${azurerm_network_interface.node[count.index].internal_domain_name_suffix}"
+  }
   
   # Using remote-execs on each instance deployment to ensure things are really
   # really up before doing to the next step, helps with Bolt plans that'll

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -73,7 +73,7 @@ resource "azurerm_linux_virtual_machine" "server" {
   tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.server_public_ip[count.index].ip_address
-    internal_fqdn = "server${count.index}.${azurerm_network_interface.server_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "${name}.${azurerm_network_interface.server_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -154,7 +154,7 @@ resource "azurerm_linux_virtual_machine" "psql" {
   tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.psql_public_ip[count.index].ip_address
-    internal_fqdn = "psql${count.index}.${azurerm_network_interface.psql_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "${name}.${azurerm_network_interface.psql_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -244,7 +244,7 @@ resource "azurerm_linux_virtual_machine" "compiler" {
     tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.compiler_public_ip[count.index].ip_address
-    internal_fqdn = "compiler${count.index}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "${name}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really
@@ -322,7 +322,7 @@ resource "azurerm_linux_virtual_machine" "node" {
     tags        = {
     Name = "pe-${var.project}-${var.id}"
     public_ip_address = azurerm_public_ip.node_public_ip[count.index].ip_address
-    internal_fqdn = "node${count.index}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
+    internal_fqdn = "${name}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
   }
   
   # Using remote-execs on each instance deployment to ensure things are really

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_network_security_group" "pe_nsg" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "pe_subnet_nsg" {
-  subnet_id                 = azurerm_subnet.examplpe_subnet.id
+  subnet_id                 = azurerm_subnet.pe_subnet.id
   network_security_group_id = azurerm_network_security_group.pe_nsg.id
 }
 

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -26,11 +26,16 @@ resource "azurerm_subnet" "pe_subnet" {
 # You can make security rules via the security group but if you
 # then creates separate security rule resource terraform is unable 
 # to track the two and will create clashes so I will use seperate rules
-resource "azurerm_network_security_group" "pe_sg" {
+resource "azurerm_network_security_group" "pe_nsg" {
   name                = "pe-${var.id}"
   location            = var.region
   resource_group_name = var.resourcegroup.name
   tags = local.name_tag
+}
+
+resource "azurerm_subnet_network_security_group_association" "pe_subnet_nsg" {
+  subnet_id                 = azurerm_subnet.examplpe_subnet.id
+  network_security_group_id = azurerm_network_security_group.pe_nsg.id
 }
 
 resource "azurerm_network_security_rule" "pe_ingressrule" {
@@ -45,5 +50,5 @@ resource "azurerm_network_security_rule" "pe_ingressrule" {
     source_address_prefixes      = var.allow
     destination_address_prefix   = "*"
     resource_group_name          = var.resourcegroup.name
-    network_security_group_name  = azurerm_network_security_group.pe_sg.name
+    network_security_group_name  = azurerm_network_security_group.pe_nsg.name
   }


### PR DESCRIPTION
The first pull request was accidentally merged but I will just get this in as completed testing and updated as per needs of autope updates and other bugs found while working on autope.

I ran the following and confirmed groups looked normal, all nodes could run puppet cleanly and generally infra seemed responsive.

`/opt/puppetlabs/bolt/bin/bolt plan run autope project=davidsand ssh_user=centos provider=azure architecture=xlarge replica=true node_count=3 compiler_count=4 firewall_allow='[ "0.0.0.0/0" ]'`

`Starting: plan autope
Starting: task terraform::initialize on localhost
Finished: task terraform::initialize with 0 failures in 0.22 sec
Starting: plan terraform::apply
Starting: task terraform::apply on localhost
Finished: task terraform::apply with 0 failures in 464.08 sec
Starting: task terraform::output on localhost
Finished: task terraform::output with 0 failures in 0.8 sec
Finished: plan terraform::apply in 7 min, 45 sec
Starting: plan peadm::install
Starting: plan peadm::subplans::install
Starting: task peadm::precheck on 8 targets
Finished: task peadm::precheck with 0 failures in 6.47 sec
Starting: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-90238-dbdgfl to /tmp/pe.conf on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-90238-10x05b1 to /tmp/pe.conf on pe-psql-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-90238-1ukpx19 to /tmp/pe.conf on pe-psql-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-90238-1ukpx19 to /tmp/pe.conf with 0 failures in 5.12 sec
Finished: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-90238-10x05b1 to /tmp/pe.conf with 0 failures in 5.16 sec
Finished: file upload from /var/folders/5p/l3pkc0rs4jz_6z71mdz2gyh80000gn/T/peadm20210705-90238-dbdgfl to /tmp/pe.conf with 0 failures in 5.53 sec
Starting: task peadm::mkdir_p_file on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::mkdir_p_file on pe-psql-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::mkdir_p_file on pe-psql-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::mkdir_p_file with 0 failures in 5.59 sec
Finished: task peadm::mkdir_p_file with 0 failures in 5.77 sec
Finished: task peadm::mkdir_p_file with 0 failures in 6.16 sec
Starting: task peadm::download on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-psql-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-psql-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::download with 0 failures in 24.55 sec
Starting: plan peadm::util::insert_csr_extension_requests
Starting: plan peadm::util::insert_csr_extension_requests
Starting: plan peadm::util::insert_csr_extension_requests
Starting: task peadm::read_file on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::read_file on pe-psql-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::read_file on pe-psql-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::read_file with 0 failures in 5.59 sec
Finished: task peadm::read_file with 0 failures in 5.6 sec
Finished: task peadm::read_file with 0 failures in 5.95 sec
Starting: task peadm::mkdir_p_file on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::mkdir_p_file on pe-psql-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::mkdir_p_file on pe-psql-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::mkdir_p_file with 0 failures in 5.6 sec
Finished: task peadm::mkdir_p_file with 0 failures in 5.85 sec
Finished: task peadm::mkdir_p_file with 0 failures in 5.98 sec
Finished: plan peadm::util::insert_csr_extension_requests in 12.08 sec
Finished: plan peadm::util::insert_csr_extension_requests in 12.07 sec
Finished: plan peadm::util::insert_csr_extension_requests in 12.58 sec
Starting: task peadm::pe_install on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::pe_install with 0 failures in 447.25 sec
Starting: task peadm::mkdir_p_file on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::mkdir_p_file with 0 failures in 6.21 sec
Starting: task peadm::pe_install on pe-psql-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-psql-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::pe_install with 0 failures in 175.96 sec
Starting: command 'systemctl stop pe-puppetdb' on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: command 'systemctl stop pe-puppetdb' with 0 failures in 2.32 sec
Starting: command 'systemctl start pe-puppetdb' on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: command 'systemctl start pe-puppetdb' with 0 failures in 48.71 sec
Starting: task peadm::rbac_token on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::rbac_token with 0 failures in 8.43 sec
Starting: task peadm::mkdir_p_file on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::mkdir_p_file with 0 failures in 6.04 sec
Starting: task peadm::code_manager on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::code_manager with 0 failures in 13.54 sec
Starting: task peadm::puppet_runonce on pe-psql-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-psql-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::agent_install on pe-compiler-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::agent_install on pe-compiler-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::agent_install on pe-compiler-davidsand-2-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::agent_install on pe-compiler-davidsand-3-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::agent_install on pe-server-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::agent_install with 0 failures in 43.19 sec
Starting: task peadm::submit_csr on pe-compiler-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::agent_install with 0 failures in 43.31 sec
Finished: task peadm::agent_install with 0 failures in 43.49 sec
Starting: task peadm::submit_csr on pe-compiler-davidsand-3-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::submit_csr on pe-server-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::agent_install with 0 failures in 45.82 sec
Starting: task peadm::submit_csr on pe-compiler-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::agent_install with 0 failures in 47.48 sec
Starting: task peadm::submit_csr on pe-compiler-davidsand-2-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::puppet_runonce with 0 failures in 53.32 sec
Finished: task peadm::submit_csr with 0 failures in 11.73 sec
Starting: task peadm::sign_csr on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::submit_csr with 0 failures in 13.42 sec
Starting: task peadm::sign_csr on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::sign_csr with 0 failures in 9.62 sec
Starting: task peadm::puppet_runonce on pe-compiler-davidsand-3-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::sign_csr with 0 failures in 9.66 sec
Starting: task peadm::puppet_runonce on pe-compiler-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::submit_csr with 0 failures in 20.97 sec
Starting: task peadm::sign_csr on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::submit_csr with 0 failures in 26.49 sec
Starting: task peadm::sign_csr on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::submit_csr with 0 failures in 26.6 sec
Starting: task peadm::sign_csr on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::sign_csr with 0 failures in 10.39 sec
Starting: task peadm::puppet_runonce on pe-compiler-davidsand-2-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::sign_csr with 0 failures in 10.47 sec
Starting: task peadm::puppet_runonce on pe-server-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::sign_csr with 0 failures in 11.23 sec
Starting: task peadm::puppet_runonce on pe-compiler-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::puppet_runonce with 0 failures in 32.13 sec
Finished: task peadm::puppet_runonce with 0 failures in 194.62 sec
Finished: task peadm::puppet_runonce with 0 failures in 204.05 sec
Finished: task peadm::puppet_runonce with 0 failures in 197.75 sec
Finished: task peadm::puppet_runonce with 0 failures in 198.81 sec
Starting: task peadm::puppet_runonce on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::puppet_runonce with 0 failures in 122.16 sec
Starting: task peadm::wait_until_service_ready on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::wait_until_service_ready with 0 failures in 6.28 sec
Starting: task peadm::puppet_runonce on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::puppet_runonce with 0 failures in 86.97 sec
Starting: task peadm::mkdir_p_file on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::mkdir_p_file on pe-psql-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Starting: task peadm::mkdir_p_file on pe-psql-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::mkdir_p_file with 0 failures in 5.68 sec
Finished: task peadm::mkdir_p_file with 0 failures in 5.97 sec
Finished: task peadm::mkdir_p_file with 0 failures in 6.03 sec
Finished: plan peadm::subplans::install in 21 min, 13 sec
Starting: plan peadm::subplans::configure
Starting: task peadm::read_file on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::read_file with 0 failures in 6.21 sec
Starting: task peadm::mkdir_p_file on pe-server-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-compiler-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-compiler-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-compiler-davidsand-2-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-compiler-davidsand-3-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::mkdir_p_file with 0 failures in 5.85 sec
Starting: apply catalog on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: apply catalog with 0 failures in 19.14 sec
Starting: task peadm::provision_replica on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::provision_replica with 0 failures in 1044.06 sec
Starting: task peadm::puppet_runonce on 8 targets
Finished: task peadm::puppet_runonce with 0 failures in 140.71 sec
Starting: command 'systemctl start puppet' on 8 targets
Finished: command 'systemctl start puppet' with 0 failures in 2.55 sec
Finished: plan peadm::subplans::configure in 20 min, 19 sec
Finished: plan peadm::install in 41 min, 32 sec
Starting: task peadm::agent_install on pe-instance-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-instance-davidsand-1-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net, pe-instance-davidsand-2-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::agent_install with 0 failures in 44.14 sec
Starting: task peadm::sign_csr on pe-server-davidsand-0-9da515.qxmqrxv1k4ruhnktyk3yqg4jka.xx.internal.cloudapp.net
Finished: task peadm::sign_csr with 0 failures in 11.6 sec
Log into Puppet Enterprise Console: https://40.125.65.154
Finished: plan autope in 50 min, 14 sec
`

![Screenshot 2021-07-05 at 14 46 15](https://user-images.githubusercontent.com/77865779/124481343-16165400-dda0-11eb-8326-8b32af9f5e9a.png)
