### PR TITLE
Solarch 495 - Validate that autope works with Terraform v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Types of things you'll be paying your cloud provider for
 * [Install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 * [AZ Login](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure)
 * [Git Installed](https://git-scm.com/downloads)
-* [Terraform (>= 0.13.0) Installed](https://www.terraform.io/downloads.html)
+* [Terraform (>= 0.13.0, <= 1.0.2) Installed](https://www.terraform.io/downloads.html)
 
 ### Beginning with terraform-azure-pe_arch
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.0, <= 1.0.2"
 }


### PR DESCRIPTION
Bumps the Terraform supported version to 1.0.2