### PR TITLE
Enable custom DNS domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,4 +126,5 @@ module "instances" {
   region             = var.region
   server_count       = data.hiera5.server_count.value
   database_count     = data.hiera5.database_count.value
+  domain_name        = var.domain_name
 }

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_linux_virtual_machine" "server" {
   # Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
   # for consistency with other providers I thought it would work best to put this tag on the instance
   tags        = merge({
-    internalDNS = "pe-server-${count.index}-${var.id}.${azurerm_network_interface.server_nic[count.index].internal_domain_name_suffix}"
+    internalDNS = var.domain_name == null ? "pe-server-${count.index}-${var.id}.${azurerm_network_interface.server_nic[count.index].internal_domain_name_suffix}" : "pe-server-${count.index}-${var.id}.${var.domain_name}"
   }, var.tags)
 }
 
@@ -171,8 +171,8 @@ resource "azurerm_linux_virtual_machine" "psql" {
 
   # Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
   # for consistency with other providers I thought it would work best to put this tag on the instance
-  tags        = merge({
-    internalDNS = "pe-psql-${count.index}-${var.id}.${azurerm_network_interface.psql_nic[count.index].internal_domain_name_suffix}"
+  tags = merge({
+    internalDNS = var.domain_name == null ? "pe-psql-${count.index}-${var.id}.${azurerm_network_interface.psql_nic[count.index].internal_domain_name_suffix}" : "pe-psql-${count.index}-${var.id}.${var.domain_name}"
   }, var.tags)
 }
 
@@ -265,7 +265,7 @@ resource "azurerm_linux_virtual_machine" "compiler" {
   # Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
   # for consistency with other providers I thought it would work best to put this tag on the instance
   tags = merge({
-    internalDNS = "pe-compiler-${count.index}-${var.id}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}"
+    internalDNS = var.domain_name == null ? "pe-compiler-${count.index}-${var.id}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}" : "pe-compiler-${count.index}-${var.id}.${var.domain_name}"
   }, var.tags)
 }
 
@@ -344,6 +344,6 @@ resource "azurerm_linux_virtual_machine" "node" {
   # Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
   # for consistency with other providers I thought it would work best to put this tag on the instance
   tags = merge({
-    internalDNS = "pe-node-${count.index}-${var.id}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}"
+    internalDNS = var.domain_name == null ? "pe-node-${count.index}-${var.id}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}" : "pe-node-${count.index}-${var.id}.${var.domain_name}"
   }, var.tags)
 }

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -82,3 +82,8 @@ variable "region" {
   description = "Region to create instances in"
   type        = string
 }
+variable "domain_name" {
+  description = "Custom domain to use for internalDNS"
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -66,3 +66,8 @@ variable "destroy" {
   type        = bool
   default     = false
 }
+variable "domain_name" {
+  description = "Custom domain to use for internalDNS"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Adds the domain_name parameter to allow setting the internalDNS tag to something with a custom domain so it can be picked up and used by Bolt