### PR TITLE
Fix node tag 

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -344,6 +344,6 @@ resource "azurerm_linux_virtual_machine" "node" {
   # Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
   # for consistency with other providers I thought it would work best to put this tag on the instance
   tags = merge({
-    internalDNS = var.domain_name == null ? "pe-node-${count.index}-${var.id}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}" : "pe-node-${count.index}-${var.id}.${var.domain_name}"
+    internalDNS = var.domain_name == null ? "pe-node-${count.index}-${var.id}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}" : "pe-node-${count.index}-${var.id}.${var.domain_name}"
   }, var.tags)
 }


### PR DESCRIPTION
There appears to be an error where node is using compiler nic instead of its own

Failed on localhost:

  Error: Invalid index

    on modules\instances\main.tf line 347, in resource "azurerm_linux_virtual_machine" "node":
   347:     internalDNS = var.domain_name == null ? "pe-node-${count.index}-${var.id}.${azurerm_network_interface.compiler_nic[count.index].internal_domain_name_suffix}" : "pe-node-${count.index}-${var.id}.${var.domain_name}"
      Ôö£ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
      Ôöé azurerm_network_interface.compiler_nic is empty tuple
      Ôöé count.index is 0

  The given key does not identify an element in this collection value: the
  collection has no elements.
Failed on 1 target: localhost