### PR TITLE
Adding windows client option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,19 +58,29 @@ resource "azurerm_resource_group" "resource_group" {
 # Collect some repeated values used by each major component module into one to
 # make them easier to update
 locals {
-  compiler_count = data.hiera5_bool.has_compilers.value ? var.compiler_count : 0
-  id              = random_id.deployment.hex
-  has_lb          = data.hiera5_bool.has_compilers.value ? true : false
-  image_id        = length(regexall("^/", var.instance_image)) > 0 ? var.instance_image : null
-  image_list      = local.image_id == null ? split(":", var.instance_image) : null
-  image_publisher = try(local.image_list[0], null)
-  image_offer     = try(local.image_list[1], null)
-  image_sku       = try(local.image_list[2], null)
-  image_version   = try(local.image_list[3], null)
-  plan_list       = try(split(":", var.image_plan), null)
-  plan_name       = try(local.plan_list[0], null)
-  plan_product    = try(local.plan_list[1], null)
-  plan_publisher  = try(local.plan_list[2], null)
+  compiler_count          = data.hiera5_bool.has_compilers.value ? var.compiler_count : 0
+  id                      = random_id.deployment.hex
+  has_lb                  = data.hiera5_bool.has_compilers.value ? true : false
+  image_id                = length(regexall("^/", var.instance_image)) > 0 ? var.instance_image : null
+  image_list              = local.image_id == null ? split(":", var.instance_image) : null
+  image_publisher         = try(local.image_list[0], null)
+  image_offer             = try(local.image_list[1], null)
+  image_sku               = try(local.image_list[2], null)
+  image_version           = try(local.image_list[3], null)
+  plan_list               = try(split(":", var.image_plan), null)
+  plan_name               = try(local.plan_list[0], null)
+  plan_product            = try(local.plan_list[1], null)
+  plan_publisher          = try(local.plan_list[2], null)
+  windows_image_id        = length(regexall("^/", var.windows_instance_image)) > 0 ? var.windows_instance_image : null
+  windows_image_list      = local.windows_image_id == null ? split(":", var.windows_instance_image) : null
+  windows_image_publisher = try(local.windows_image_list[0], null)
+  windows_image_offer     = try(local.windows_image_list[1], null)
+  windows_image_sku       = try(local.windows_image_list[2], null)
+  windows_image_version   = try(local.windows_image_list[3], null)
+  windows_plan_list       = try(split(":", var.windows_image_plan), null)
+  windows_plan_name       = try(local.windows_plan_list[0], null)
+  windows_plan_product    = try(local.windows_plan_list[1], null)
+  windows_plan_publisher  = try(local.windows_plan_list[2], null)
   tags            = merge({
     description = "PEADM Deployed Puppet Enterprise"
     project     = var.project
@@ -104,27 +114,36 @@ module "loadbalancer" {
 
 # Contain all the instances configuration in a module for readability
 module "instances" {
-  source             = "./modules/instances"
-  id                 = local.id
-  virtual_network_id = module.networking.virtual_network_id
-  subnet_id          = module.networking.subnet_id
-  user               = var.user
-  ssh_key            = var.ssh_key
-  compiler_count     = local.compiler_count
-  node_count         = var.node_count
-  tags               = local.tags
-  image_id           = local.image_id
-  image_publisher    = local.image_publisher
-  image_offer        = local.image_offer
-  image_sku          = local.image_sku
-  image_version      = local.image_version
-  plan_name          = local.plan_name
-  plan_product       = local.plan_product
-  plan_publisher     = local.plan_publisher
-  project            = var.project
-  resource_group     = azurerm_resource_group.resource_group
-  region             = var.region
-  server_count       = data.hiera5.server_count.value
-  database_count     = data.hiera5.database_count.value
-  domain_name        = var.domain_name
+  source                  = "./modules/instances"
+  id                      = local.id
+  virtual_network_id      = module.networking.virtual_network_id
+  subnet_id               = module.networking.subnet_id
+  user                    = var.user
+  ssh_key                 = var.ssh_key
+  compiler_count          = local.compiler_count
+  node_count              = var.node_count
+  windows_node_count      = var.windows_node_count 
+  tags                    = local.tags
+  image_id                = local.image_id
+  image_publisher         = local.image_publisher
+  image_offer             = local.image_offer
+  image_sku               = local.image_sku
+  image_version           = local.image_version
+  plan_name               = local.plan_name
+  plan_product            = local.plan_product
+  plan_publisher          = local.plan_publisher
+  windows_image_id        = local.windows_image_id
+  windows_image_publisher = local.windows_image_publisher
+  windows_image_offer     = local.windows_image_offer
+  windows_image_sku       = local.windows_image_sku
+  windows_image_version   = local.windows_image_version
+  windows_plan_name       = local.windows_plan_name
+  windows_plan_product    = local.windows_plan_product
+  windows_plan_publisher  = local.windows_plan_publisher
+  project                 = var.project
+  resource_group          = azurerm_resource_group.resource_group
+  region                  = var.region
+  server_count            = data.hiera5.server_count.value
+  database_count          = data.hiera5.database_count.value
+  domain_name             = var.domain_name
 }

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -417,6 +417,10 @@ resource "azurerm_windows_virtual_machine" "windows_node" {
     }
   }
 
+  winrm_listener {
+    protocol = 'Http'
+  }
+
   # Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
   # for consistency with other providers I thought it would work best to put this tag on the instance
   tags = merge({

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -2,6 +2,8 @@ locals {
   av_set = var.compiler_count > 0 ? 1 : 0
   dynamic_image_reference = var.image_id == null ? [1] : []
   dynamic_image_plan = var.image_id == null ? length(compact([var.plan_name, var.plan_product, var.plan_publisher])) == 3 ? [1] : []  : []
+  windows_dynamic_image_reference = var.windows_image_id == null ? [1] : []
+  windows_dynamic_image_plan = var.windows_image_id == null ? length(compact([var.windows_plan_name, var.windows_plan_product, var.windows_plan_publisher])) == 3 ? [1] : []  : []
 }
 
 resource "azurerm_ssh_public_key" "pe_adm" {
@@ -151,21 +153,21 @@ resource "azurerm_linux_virtual_machine" "psql" {
   source_image_id = var.image_id
 
   dynamic "source_image_reference" {
-    for_each = local.dynamic_image_reference
+    for_each = local.windows_dynamic_image_reference
     content {
-      publisher = var.image_publisher
-      offer     = var.image_offer
-      sku       = var.image_sku
-      version   = var.image_version
+      publisher = var.windows_image_publisher
+      offer     = var.windows_image_offer
+      sku       = var.windows_image_sku
+      version   = var.windows_image_version
     }
   }
 
   dynamic "plan" {
-    for_each = local.dynamic_image_plan
+    for_each = local.windows_dynamic_image_plan
     content {
-      name      = var.plan_name
-      product   = var.plan_product
-      publisher = var.plan_publisher
+      name      = var.windows_plan_name
+      product   = var.windows_plan_product
+      publisher = var.windows_plan_publisher
     }
   }
 
@@ -345,5 +347,79 @@ resource "azurerm_linux_virtual_machine" "node" {
   # for consistency with other providers I thought it would work best to put this tag on the instance
   tags = merge({
     internalDNS = var.domain_name == null ? "pe-node-${count.index}-${var.id}.${azurerm_network_interface.node_nic[count.index].internal_domain_name_suffix}" : "pe-node-${count.index}-${var.id}.${var.domain_name}"
+  }, var.tags)
+}
+
+resource "azurerm_public_ip" "windows_node_public_ip" {
+  name                = "pe-windows-node-${count.index}-${var.id}"
+  resource_group_name = var.resource_group.name
+  location            = var.region
+  count               = var.windows_node_count
+  allocation_method   = "Static"
+  tags = var.tags
+}
+
+resource "azurerm_network_interface" "windows_node_nic" {
+  name                = "pe-windows-node-${count.index}-${var.id}"
+  location            = var.region
+  count               = var.windows_node_count
+  resource_group_name = var.resource_group.name
+  tags                = var.tags
+  ip_configuration {
+    name                          = "windows-node"
+    subnet_id                     = var.subnet_id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.windows_node_public_ip[count.index].id
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "windows_node" {
+  name                   = "pe-windows-node-${count.index}-${var.id}"
+  computer_name          = "pe-wn-${count.index}-${var.id}"
+  count                  = var.windows_node_count
+  resource_group_name    = var.resource_group.name
+  location               = var.region
+  size                   = "Standard_D4_v4"
+  admin_username         = var.user
+  admin_password         = "Pupp3tL@b5P0rtl@nd!"
+  network_interface_ids  = [
+    azurerm_network_interface.windows_node_nic[count.index].id,
+  ]
+
+  depends_on = [
+    azurerm_network_interface.windows_node_nic
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+    disk_size_gb         = 30
+  }
+  
+  source_image_id = var.windows_image_id
+
+  dynamic "source_image_reference" {
+    for_each = local.windows_dynamic_image_reference
+    content {
+      publisher = var.windows_image_publisher
+      offer     = var.windows_image_offer
+      sku       = var.windows_image_sku
+      version   = var.windows_image_version
+    }
+  }
+
+  dynamic "plan" {
+    for_each = local.windows_dynamic_image_plan
+    content {
+      name      = var.windows_plan_name
+      product   = var.windows_plan_product
+      publisher = var.windows_plan_publisher
+    }
+  }
+
+  # Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS
+  # for consistency with other providers I thought it would work best to put this tag on the instance
+  tags = merge({
+    internalDNS = "pe-windows-node-${count.index}-${var.id}.${azurerm_network_interface.windows_node_nic[count.index].internal_domain_name_suffix}"
   }, var.tags)
 }

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -380,8 +380,8 @@ resource "azurerm_windows_virtual_machine" "windows_node" {
   resource_group_name    = var.resource_group.name
   location               = var.region
   size                   = "Standard_D4_v4"
-  admin_username         = var.user
-  admin_password         = "Pupp3tL@b5P0rtl@nd!"
+  admin_username         = var.windows_user
+  admin_password         = var.windows_password
   network_interface_ids  = [
     azurerm_network_interface.windows_node_nic[count.index].id,
   ]
@@ -418,7 +418,7 @@ resource "azurerm_windows_virtual_machine" "windows_node" {
   }
 
   winrm_listener {
-    protocol = 'Http'
+    protocol = "Http"
   }
 
   # Due to the nature of azure resources there is no single resource which presents in terraform both public IP and internal DNS

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -11,6 +11,17 @@ variable "ssh_key" {
   description = "Location on disk of the SSH public key to be used for instance SSH access"
   type        = string
 }
+
+variable "windows_user" {
+  description = "Instance user name that will used for WINRM operations"
+  type        = string
+}
+variable "windows_password" {
+  description = "Password to be used for instance WINRM access"
+  type        = string
+  sensitive   = true
+}
+
 variable "compiler_count" {
   description = "The quantity of compilers that are deployed behind a load balancer and will be spread across defined zones"
   type        = number

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -74,6 +74,42 @@ variable "node_count" {
   description = "The quantity of nodes that are deployed within the environment for testing"
   type        = number
 }
+
+variable "windows_image_id" {
+  description = "The custom image ID to use for deploying new cloud instances"
+}
+variable "windows_image_offer" {
+  description = "The Marketplace image offer to use when deploying new cloud instances"
+  type        = string
+}
+variable "windows_image_publisher" {
+  description = "The Marketplace image publisher to deploy from for new cloud instances"
+  type        = string
+}
+variable "windows_image_version" {
+  description = "The Marketplace image version to deploy from for new cloud instances"
+  type        = string
+}
+variable "windows_image_sku" {
+  description = "The Marketplace sku to use when deploying new cloud instances"
+  type        = string
+}
+variable "windows_plan_name" {
+  description = "The Marketplace image plan name"
+}
+variable "windows_plan_product" {
+  description = "The Marketplace image product name"
+  type        = string
+}
+variable "windows_plan_publisher" {
+  description = "The Marketplace image publisher name"
+  type        = string
+}
+variable "windows_node_count" {
+  description = "The quantity of windows nodes that are deployed within the environment for testing"
+  type        = number
+}
+
 variable "tags" {
   description = "A set of tags that will be assigned to resources along with required"
   type        = map

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,23 @@ variable "image_plan" {
   type        = string
   default     = "8-gen2:almalinux:almalinux"
 }
+
+variable "windows_node_count" {
+  description = "The quantity of nodes that are deployed within the environment for testing"
+  type        = number
+  default     = 1
+}
+variable "windows_instance_image" {
+  description = "The disk image to use when deploying new cloud instances in the form of a full length Image ID or Marketplace URN"
+  type        = string
+  default     = "MicrosoftWindowsServer:WindowsServer:2022-datacenter-azure-edition-smalldisk:latest"
+}
+variable "windows_image_plan" {
+  description = "The Marketplace offering's plan if it has one in Marketplace URN style, name:product:publisher"
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "A set of tags that will be assigned to resources along with required"
   type        = map

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,15 @@ variable "user" {
   description = "Instance user name that will used for SSH operations"
   type        = string
 }
+variable "windows_user" { 
+  description = "Instance user name that will used for WINRM operations"
+  type        = string
+}
+variable "windows_password" { 
+  description = "Password that will used for WINRM operations"
+  type        = string
+  sensitive   = true
+}
 variable "ssh_key" {
   description = "Location on disk of the SSH public key to be used for instance SSH access"
   type        = string
@@ -22,7 +31,7 @@ variable "compiler_count" {
   default     = 1
 }
 variable "node_count" {
-  description = "The quantity of nodes that are deployed within the environment for testing"
+  description = "The quantity of Linux nodes that are deployed within the environment for testing"
   type        = number
   default     = 0
 }


### PR DESCRIPTION
This adds the capability of requesting windows nodes. To keep things simple the general choice was made to use windows_ and mimic the behaviour of the pre-existing linux node options. 

The computer name in windows was too short for our standard naming so to keep things simple a shortened computer name is used but the longer windows_name everywhere else.