### PR TITLE
Changing default nodes to 0 for windows

### DIFF
--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_subnet_network_security_group_association" "pe_subnet_nsg" {
 }
 
 resource "azurerm_network_security_rule" "pe_ingressrule" {
-  name                         = "General ingress rule"
+  name                         = "General_ingress_rule"
   count                        = length(var.allow) >= 1 ? 1 : 0
   priority                     = 1000
   direction                    = "Inbound"

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,7 @@ variable "windows_password" {
   description = "Password that will used for WINRM operations"
   type        = string
   sensitive   = true
+  default     = null
 }
 variable "ssh_key" {
   description = "Location on disk of the SSH public key to be used for instance SSH access"
@@ -49,7 +50,7 @@ variable "image_plan" {
 variable "windows_node_count" {
   description = "The quantity of nodes that are deployed within the environment for testing"
   type        = number
-  default     = 1
+  default     = 0
 }
 variable "windows_instance_image" {
   description = "The disk image to use when deploying new cloud instances in the form of a full length Image ID or Marketplace URN"


### PR DESCRIPTION
This change corrects the azure Terraform plugin to expect zero windows nodes and corrects an error in network rule names that was introduced.